### PR TITLE
Add link to python type hint tutorial gist

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -202,6 +202,7 @@ This section is for both single functions and applications composed of multiple 
 
 * [AWS IOT Button Example](https://github.com/mongoose-os-apps/aws-iot-button) - This is an Internet Button reference project: when a button on the device is pressed, a cloud backend gets a notification and performs an action. In this particular case, AWS Lambda function sends an email to the specific email address.
 * [aws-lambda-vpc-nat-examples](https://github.com/ittus/aws-lambda-vpc-nat-examples) - Example of setting up AWS lambda function with VPC and NAT.
+* [How to Use Python 3 Type Hints in AWS Lambda](https://gist.github.com/alexcasalboni/a545b68ee164b165a74a20a5fee9d133) - Static Type Checkers help you find simple (but subtle) bugs in your Python code. Check out lambda_types.py and incrementally improve your code base and development/debugging experience with type hints.
 * [Lambda Tutorial: Lambda + Serverless = HAPPY](https://www.youtube.com/watch?v=71cd5XerKss)
 * [Learning Lambda](https://blog.symphonia.io/learning-lambda-1f25af64161c) - Mike Roberts' series on learning to use Lambda
 * [Nightmare-lambda-tutorial](https://github.com/dimkir/nightmare-lambda-tutorial) - A sample project and tutorial to show how to run NightmareJS on AWS Lambda.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- If you're unsure about anything in this checklist, don't hesitate to create a PR and ask. I'm happy to help! -->

# Description

Add link to [How to Use Python 3 Type Hints in AWS Lambda](https://gist.github.com/alexcasalboni/a545b68ee164b165a74a20a5fee9d133)

# Type of changes

<!--- What types of changes does your submission introduce? Put an `x` in all the boxes that apply: -->

- [x] A link to an external resource like a blog post or video
- [ ] Add/remove a lambda function
- [ ] Add/remove a framework
- [ ] Text cleanups/typo fixes

# Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I have confirmed that the link(s) in my PR are valid.
- [x] My entries are single lines (unless they're a framework) and are in the appropriate (functions, frameworks, resources) section.
- [x] My entries have been added in alphabetical order in their section.
- [x] I have read the **CONTRIBUTING** document.
- [x] All new and existing tests passed.
- [x] I have stripped leading **aws-** or **aws-lambda-** from the link name. This makes it easier to find things by name since there aren't big clusters in the A sections of the lists
- [x] This list is Apache 2.0 licensed, and I agree that my PR is subject to that license.
